### PR TITLE
ci: build landscaper image from source in unit tests (avoid stale :main race)

### DIFF
--- a/.github/workflows/unittest1.yml
+++ b/.github/workflows/unittest1.yml
@@ -14,6 +14,8 @@ jobs:
         steps:
             - name: checkout code
               uses: actions/checkout@v3
+            - name: Build landscaper image from current source (avoid stale :main pull)
+              run: docker build -t ghcr.io/chiba-ai-med/landscaper:main .
             - name: src/test.sh
               run: |
                   echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u kokitsuyuzaki --password-stdin && src/test.sh

--- a/.github/workflows/unittest2.yml
+++ b/.github/workflows/unittest2.yml
@@ -14,6 +14,8 @@ jobs:
         steps:
             - name: checkout code
               uses: actions/checkout@v3
+            - name: Build landscaper image from current source (avoid stale :main pull)
+              run: docker build -t ghcr.io/chiba-ai-med/landscaper:main .
             - name: src/test_01.sh
               run: |
                   echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u kokitsuyuzaki --password-stdin && src/test_01.sh

--- a/.github/workflows/unittest3.yml
+++ b/.github/workflows/unittest3.yml
@@ -14,6 +14,8 @@ jobs:
         steps:
             - name: checkout code
               uses: actions/checkout@v3
+            - name: Build landscaper image from current source (avoid stale :main pull)
+              run: docker build -t ghcr.io/chiba-ai-med/landscaper:main .
             - name: src/test_cont.sh
               run: |
                   echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u kokitsuyuzaki --password-stdin && src/test_cont.sh

--- a/.github/workflows/unittest4.yml
+++ b/.github/workflows/unittest4.yml
@@ -14,6 +14,8 @@ jobs:
         steps:
             - name: checkout code
               uses: actions/checkout@v3
+            - name: Build landscaper image from current source (avoid stale :main pull)
+              run: docker build -t ghcr.io/chiba-ai-med/landscaper:main .
             - name: src/test_cov.sh
               run: |
                   echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u kokitsuyuzaki --password-stdin && src/test_cov.sh

--- a/.github/workflows/unittest5.yml
+++ b/.github/workflows/unittest5.yml
@@ -14,6 +14,8 @@ jobs:
         steps:
             - name: checkout code
               uses: actions/checkout@v3
+            - name: Build landscaper image from current source (avoid stale :main pull)
+              run: docker build -t ghcr.io/chiba-ai-med/landscaper:main .
             - name: src/test_sparse.sh
               run: |
                   echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u kokitsuyuzaki --password-stdin && src/test_sparse.sh


### PR DESCRIPTION
## Problem
The unit-test workflows (`unittest1`–`5`) and the image-build workflow (`build_test_push.yml`) both trigger on `push`/`pull_request` and run **in parallel**. Each `src/test*.sh` pulls `ghcr.io/chiba-ai-med/landscaper:main` and runs the pipeline from it. Because the `Dockerfile` **bakes the source into the image** (`ADD src /src`, `Snakefile`, `landscaper`), the tests run the pipeline against whatever `:main` happened to be published at pull time — usually the **previous** commit's source.

This race was invisible until now (old tests didn't assert basin validity). The basin fix in v1.7.1 added a regression test that correctly detected the stale image, surfacing the race as a CI failure that only passed on manual re-run.

## Fix
Build the image locally from the checked-out source and tag it `:main` **before** running `test*.sh`:

```yaml
- name: Build landscaper image from current source (avoid stale :main pull)
  run: docker build -t ghcr.io/chiba-ai-med/landscaper:main .
```

`docker run ... :main` then uses the freshly built local image (pull policy `missing` → no pull), so the pipeline always runs the **current commit's** source.

## Cost
Negligible. The `Dockerfile` is `FROM koki/landscaper_component:latest` + `ADD` source; the base image is pulled for the testthat step anyway, so this only layers source on top (seconds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)